### PR TITLE
Fix ExampleController closing

### DIFF
--- a/app/app/Http/Controllers/ExampleController.php
+++ b/app/app/Http/Controllers/ExampleController.php
@@ -14,5 +14,4 @@ class ExampleController extends Controller
         //
     }
 
-    //
 }


### PR DESCRIPTION
## Summary
- remove stray trailing comment from ExampleController

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684b134c5d988328a8f5f0e41424cff5